### PR TITLE
Portions

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -39,5 +39,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCHES: main
           WITH_V: true
-          DEFAULT_BUMP: none
+          DEFAULT_BUMP: minor
 #          PRERELEASE_SUFFIX: beta

--- a/gows/ws.go
+++ b/gows/ws.go
@@ -121,17 +121,37 @@ func (w *WS) getCDF(pdf touples) (cdf touples) {
 }
 
 func (w *WS) indexes(settings Settings, calculatedIndexes []int) (indexes []int) {
-	if settings == IgnoreIndexesForZeroPDF {
-		for _, v := range calculatedIndexes {
-			indexes = append(indexes, w.filteredPDFFromZeroElements[v].index)
+	if len(calculatedIndexes) == len(w.pdf) {
+		return calculatedIndexes
+	}
+
+	indexes = w.toPDFIndexes(calculatedIndexes)
+
+	switch settings {
+	case IgnoreIndexesForZeroPDF:
+		return indexes
+	case KeepIndexesForZeroPDF:
+		for i := 0; i < len(w.pdf); i++ {
+			apnd := true
+			for _, v := range calculatedIndexes {
+				if w.filteredPDFFromZeroElements[v].index == i {
+					apnd = false
+					break
+				}
+			}
+			if apnd {
+				indexes = append(indexes, i)
+			}
 		}
 		return indexes
+	default:
+		return indexes
 	}
-	for i := 0; i < len(w.pdf); i++ {
-		indexes = append(indexes, i)
-	}
-	for i, v := range calculatedIndexes {
-		indexes[i], indexes[w.filteredPDFFromZeroElements[v].index] = indexes[w.filteredPDFFromZeroElements[v].index], indexes[i]
+}
+
+func (w *WS) toPDFIndexes(calculatedIndexes []int) (indexes []int) {
+	for _, v := range calculatedIndexes {
+		indexes = append(indexes, w.filteredPDFFromZeroElements[v].index)
 	}
 	return indexes
 }


### PR DESCRIPTION
portions are compatible with percentages.
We can define pdfs as portions and not as percentages.
It will also simplify the validation, where the 100% rule for PDF does not have to be checked.

Signed-off-by: kuritka <kuritka@gmail.com>
