### PR TITLE
Implement portions

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -39,5 +39,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCHES: main
           WITH_V: true
-          DEFAULT_BUMP: none
+          DEFAULT_BUMP: minor
 #          PRERELEASE_SUFFIX: beta


### PR DESCRIPTION
portions are compatible with percentages.
We can define pdfs as portions and not as percentages.
It will also simplify the validation, where the 100% rule
for PDF does not have to be checked.

Signed-off-by: kuritka <kuritka@gmail.com>
